### PR TITLE
[CCXDEV-10595] Ams token as secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ clean: ## Run go clean
 
 build: ${BINARY} ## Build binary containing service executable
 
+build-cover:	${SOURCES}  ## Build binary with code coverage detection support
+	./build.sh -cover
+
 ${BINARY}: ${SOURCES}
 	./build.sh
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Available targets are:
 
 clean                Run go clean
 build                Build binary containing service executable
+build-cover          Build binary with code coverage detection support
 fmt                  Run go fmt -w for all sources
 lint                 Run golint
 vet                  Run go vet. Report likely mistakes in source code

--- a/build.sh
+++ b/build.sh
@@ -22,5 +22,5 @@ commit=$(git rev-parse HEAD)
 
 utils_version=$(go list -m github.com/RedHatInsights/insights-operator-utils | awk '{print $2}')
 
-go build -ldflags="-X 'main.BuildTime=$buildtime' -X 'main.BuildVersion=$version' -X 'main.BuildBranch=$branch' -X 'main.BuildCommit=$commit' -X 'main.UtilsVersion=$utils_version'"
+go build "$@" -ldflags="-X 'main.BuildTime=$buildtime' -X 'main.BuildVersion=$version' -X 'main.BuildBranch=$branch' -X 'main.BuildCommit=$commit' -X 'main.UtilsVersion=$utils_version'"
 exit $?

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -135,6 +135,8 @@ objects:
                   optional: true
             - name: INSIGHTS_RESULTS_SMART_PROXY__AMSCLIENT__PAGE_SIZE
               value: ${AMS_API_PAGESIZE}
+            - name: INSIGHTS_RESULTS_SMART_PROXY__AMSCLIENT__TOKEN
+              value: ${AMS_TOKEN}
           image: ${IMAGE}:${IMAGE_TAG}
           livenessProbe:
             failureThreshold: 3
@@ -263,3 +265,5 @@ parameters:
   value: "10000"
 - name: ORG_CLUSTERS_FALLBACK
   value: "false"
+- name: AMS_TOKEN
+  value: ""

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -136,7 +136,11 @@ objects:
             - name: INSIGHTS_RESULTS_SMART_PROXY__AMSCLIENT__PAGE_SIZE
               value: ${AMS_API_PAGESIZE}
             - name: INSIGHTS_RESULTS_SMART_PROXY__AMSCLIENT__TOKEN
-              value: ${AMS_TOKEN}
+              valueFrom:
+                secretKeyRef:
+                  name: ams-client-auth
+                  key: amsclient_token
+                  optional: true
           image: ${IMAGE}:${IMAGE_TAG}
           livenessProbe:
             failureThreshold: 3
@@ -265,5 +269,3 @@ parameters:
   value: "10000"
 - name: ORG_CLUSTERS_FALLBACK
   value: "false"
-- name: AMS_TOKEN
-  value: ""


### PR DESCRIPTION
# Description

Setting the AMS client TOKEN to be read from the same secret that might have client ID and secret

## Type of change

- Configuration update

## Testing steps


## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
